### PR TITLE
Argument items are not null anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"require": {
 		"php": "^8.1",
 		"ext-dom": "*",
-		"latte/latte": "^3.0",
+		"latte/latte": "^3.0.9",
 		"nette/application": "^3.1",
 		"nette/di": "^3.1.2",
 		"nette/schema": "^1.2"

--- a/src/Nodes/IconNodeFactory.php
+++ b/src/Nodes/IconNodeFactory.php
@@ -34,9 +34,6 @@ class IconNodeFactory
 		}
 		$cssClasses = $this->cssClass ? [$this->cssClass] : [];
 		foreach ($tag->parser->parseArguments()->items as $argument) {
-			if (!$argument) {
-				continue;
-			}
 			if (!$argument->value instanceof StringNode) {
 				throw new IconTagException('Only strings supported', $tag, $resource);
 			}


### PR DESCRIPTION
This was changed in 3.0.7 but let's require the current newest version, what can go wrong.

This is where it was changed: https://github.com/nette/latte/commit/caad6b50bcdc0ae3269808f13fe52cec718026cb#diff-afce0d177ca97fc50a1ffcbae1508a38c5759c2f8f3cef88c1497a244a639bb9L24